### PR TITLE
Stabilize animator and fix export lint blockers

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,5 @@
 import { app, BrowserWindow } from 'electron'
+import process from 'process'
 import path from 'path'
 import { fileURLToPath } from 'url'
 

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -31,20 +31,17 @@ export function Controls() {
   const store = useStore()
   const {
     ui, toggleControls, // UI State
-    image, setImage,
+    setImage,
     transforms, setTransform,
     symmetry, setSymmetry,
     warp, setWarp,
     displacement, setDisplacement,
     tiling, setTiling,
-    masking, setMasking,
-    recording, setRecording,
-    generator, setGenerator,
+    masking,
     color, setColor,
     effects, setEffects,
     snapshots, addSnapshot, deleteSnapshot, loadSnapshot,
     animation, setAnimation,
-    randomize, resetTransforms,
     toggleHelp
   } = useStore()
 
@@ -76,6 +73,7 @@ export function Controls() {
       }
       reader.readAsDataURL(file)
     } catch (err) {
+      console.error(err)
       alert("Unexpected error during upload.")
     }
   }
@@ -118,6 +116,7 @@ export function Controls() {
           useStore.setState(data.state)
         }
       } catch (err) {
+        console.error(err)
         alert("Failed to load project file.")
       }
     }

--- a/src/components/DebugOverlay.jsx
+++ b/src/components/DebugOverlay.jsx
@@ -5,9 +5,8 @@ export function DebugOverlay() {
   const state = useStore()
   const { image, canvas, transforms } = state
 
-  // if (!window.location.search.includes('debug') && !import.meta.env.DEV) return null
-  // Always show for this troubleshooting session
-  if (false) return null
+  const shouldShow = window.location.search.includes('debug') || import.meta.env.DEV
+  if (!shouldShow) return null
 
   return (
     <div className="fixed bottom-4 left-4 p-4 bg-black/90 text-green-400 font-mono text-xs z-[100] pointer-events-none border border-green-800 rounded opacity-80">

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -94,7 +94,6 @@ export const useStore = create((set) => ({
     controlsOpen: true,
   },
 
-  toggleHelp: (isOpen) => set((state) => ({ ui: { ...state.ui, helpOpen: isOpen } })),
   toggleControls: (isOpen) => set((state) => ({ ui: { ...state.ui, controlsOpen: isOpen } })),
 
   recording: { isActive: false, progress: 0 },


### PR DESCRIPTION
## Summary
- stabilize CanvasGL uniforms and texture handling for exports and runtime updates
- fix animator hook dependencies and clean up unused controls and store keys
- address Electron process reference and debug overlay guard

## Testing
- npm run lint
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693846c860248331b7ca69639de3eee6)