### PR TITLE
Handle media uploads and preserve audio settings on reset

### DIFF
--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -483,9 +483,10 @@ export const useStore = create(
           generator: { ...DEFAULTS.generator, type: state.generator.type },
           color: { ...DEFAULTS.color },
           effects: { ...DEFAULTS.effects },
-          flux: { ...DEFAULTS.flux },
-          lfo: { ...DEFAULTS.lfo },
-          audio: { ...DEFAULTS.audio },
+          // Keep global modulation/audio state when doing a soft reset
+          flux: { ...state.flux },
+          lfo: { ...state.lfo },
+          audio: { ...state.audio },
           animation: { ...state.animation, isPlaying: false } // Stop playing but keep timeline
         }))
       },


### PR DESCRIPTION
## Summary
- support video uploads by creating a playable video texture instead of treating videos as images
- fix toggle knob alignment styling for clearer state feedback
- keep flux, LFO, and audio settings intact during soft parameter resets

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e3f30a0483318d3ef2ee74903864)